### PR TITLE
Don't confuse people with negative earnings

### DIFF
--- a/Includes/Include.ps1
+++ b/Includes/Include.ps1
@@ -1719,7 +1719,9 @@ Function Get-DisplayCurrency {
         [Parameter(Mandatory = $false)]
         [Decimal]$Factor=1
     )
-    
+    if ($Value -lt 0){
+        $Value = 0	
+    }
     $Result = [PSCustomObject]@{
         Currency = If($Config.Passwordcurrency -eq "BTC") {"$([char]0x20BF)"} Else {$Config.Passwordcurrency}
         Value = $Value * $Factor

--- a/NPlusMiner.ps1
+++ b/NPlusMiner.ps1
@@ -339,7 +339,12 @@ Function Global:TimerUITick
                         {$_ -lt 0}
                             {"<"}
                     }
-                $LabelEarningsDetails.Lines += "Last  1h: " + ((Get-DisplayCurrency ($Variables.Earnings.Values | measure -Property Growth1 -Sum).sum 24)).DisplayStringPerDay + " " + $TrendSign
+                if ($Variables.Earnings.Values.Growth1 -lt 0) {
+                    $LabelEarningsDetails.Lines += "Last  1h: Mine Longer"
+                } else {
+                    $LabelEarningsDetails.Lines += "Last  1h: " + ((Get-DisplayCurrency ($Variables.Earnings.Values | measure -Property Growth1 -Sum).sum 24)).DisplayStringPerDay + " " + $TrendSign
+                }
+                
                 $TrendSign = switch ([Math]::Round((($Variables.Earnings.Values | measure -Property Growth6 -Sum).sum*1000*4),3) - [Math]::Round((($Variables.Earnings.Values | measure -Property Growth24 -Sum).sum*1000),3)) {
                         {$_ -eq 0}
                             {"="}
@@ -348,7 +353,11 @@ Function Global:TimerUITick
                         {$_ -lt 0}
                             {"<"}
                     }
-                $LabelEarningsDetails.Lines += "Last  6h: " + ((Get-DisplayCurrency ($Variables.Earnings.Values | measure -Property Growth6 -Sum).sum 4)).DisplayStringPerDay + " " + $TrendSign
+                if ($Variables.Earnings.Values.Growth6 -lt 0) {
+                    $LabelEarningsDetails.Lines += "Last  6h: Mine Longer"
+                } else {
+                    $LabelEarningsDetails.Lines += "Last  6h: " + ((Get-DisplayCurrency ($Variables.Earnings.Values | measure -Property Growth6 -Sum).sum 4)).DisplayStringPerDay + " " + $TrendSign
+                }
                 $TrendSign = switch ([Math]::Round((($Variables.Earnings.Values | measure -Property Growth24 -Sum).sum*1000),3) - [Math]::Round((($Variables.Earnings.Values | measure -Property BTCD -Sum).sum*1000*0.96),3)) {
                         {$_ -eq 0}
                             {"="}
@@ -357,7 +366,11 @@ Function Global:TimerUITick
                         {$_ -lt 0}
                             {"<"}
                     }
-                $LabelEarningsDetails.Lines += "Last 24h: " + ((Get-DisplayCurrency ($Variables.Earnings.Values | measure -Property Growth24 -Sum).sum)).DisplayStringPerDay + " " + $TrendSign
+                if ($Variables.Earnings.Values.Growth24 -lt 0) {
+                    $LabelEarningsDetails.Lines += "Last 24h: Mine Longer"
+                } else {
+                    $LabelEarningsDetails.Lines += "Last 24h: " + ((Get-DisplayCurrency ($Variables.Earnings.Values | measure -Property Growth24 -Sum).sum)).DisplayStringPerDay + " " + $TrendSign
+                }
                 rv TrendSign
             } else {
                 $LabelBTCD.Text = "Waiting data from pools."


### PR DESCRIPTION
I've seen many people ask about why they are "loosing money" due to negative earnings being showed.
Got tired of explaining it to people, so I created this patch. 

-  Added a check to `Get-DisplayCurrency` to turn negative numbers into zero - stops negative values from being seen in the pools section
- If last 1h, 6h, or 24h earnings are negative, inform the user they need to keep mining
![Without Patch](https://user-images.githubusercontent.com/17304943/119185084-26aa7f00-ba2b-11eb-823e-02ef86222547.PNG)
![With Patch](https://user-images.githubusercontent.com/17304943/119185130-404bc680-ba2b-11eb-8538-d15674cd8bb8.PNG)
